### PR TITLE
Include Fluvius fees in total sum

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The integration creates the following sensors:
 - FL Zenne-Dijle Vergoeding
 - Energiebijdrage
 - Verbruik 0-12kWh
-- Totaal (som van bovenstaande waarden)
+- Totaal (som van maandelijkse prijs, FL Zenne-Dijle afname en vergoeding, energiebijdrage en verbruik 0-12kWh)
 
 ## Update strategie
 


### PR DESCRIPTION
## Summary
- update the total calculation to include the Fluvius afname/vergoeding values and log missing components when the sum cannot be determined
- document the expanded total composition in the README

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cbfe23c3f0832fbbed1adb41e71b2c